### PR TITLE
feat: add monitoring template for Zookeeper servers

### DIFF
--- a/operator/charts/helm/zookeeper-service/templates/_helpers.tpl
+++ b/operator/charts/helm/zookeeper-service/templates/_helpers.tpl
@@ -359,6 +359,14 @@ Find a zookeeper-backup-daemon image in various places.
   {{- join "," $zookeeperHosts -}}
 {{- end -}}
 
+{{- define "monitoring.zookeeperServers" -}}
+  {{- $servers := list -}}
+  {{- range $replica, $e := until ((include "zookeeper.replicas" . ) | int) -}}
+    {{- $servers = append $servers (printf "\"%s-%d:2181\"" (include "zookeeper.name" $) (add1 $replica)) }}
+  {{- end -}}
+  [{{ join ", " $servers }}]
+{{- end -}}
+
 {{/*
 Backup Daemon Protocol
 */}}

--- a/operator/charts/helm/zookeeper-service/templates/zookeeper-monitoring-configuration.yaml
+++ b/operator/charts/helm/zookeeper-service/templates/zookeeper-monitoring-configuration.yaml
@@ -173,7 +173,7 @@ data:
 
     ## If no servers are specified, then localhost is used as the host.
     ## If no port is specified, 2181 is used
-    servers = ["$ZOOKEEPER_HOST"]
+    servers = {{ template "monitoring.zookeeperServers" . }}
     timeout = "10s"
     fieldpass = ["znode_count", "ephemerals_count", "approximate_data_size", "avg_latency", "min_latency", "max_latency", "num_alive_connections", "packets_received", "packets_sent"]
 


### PR DESCRIPTION
- Introduced a new template function `monitoring.zookeeperServers` to dynamically generate a list of Zookeeper server addresses for monitoring configuration.
- Updated the Zookeeper monitoring configuration to utilize the new template for server addresses, enhancing flexibility and maintainability.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue CPCAP-10881
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
