### PR TITLE
fix: add auto-restart secret annotations to reconciler logic for Back…

### DIFF
--- a/operator/controllers/backupdaemon_reconciler.go
+++ b/operator/controllers/backupdaemon_reconciler.go
@@ -156,6 +156,7 @@ func (r ReconcileBackupDaemon) Reconcile() error {
 		if err := controllerutil.SetControllerReference(r.cr, deployment, r.reconciler.Scheme); err != nil {
 			return err
 		}
+		applyAutoRestartSecretAnnotations(deployment, r.logger, backupDaemonSecret, s3Secret, s3AliasesSecret)
 		if err := r.reconciler.createOrUpdateDeployment(deployment, r.logger); err != nil {
 			return err
 		}

--- a/operator/controllers/monitoring_reconciler.go
+++ b/operator/controllers/monitoring_reconciler.go
@@ -128,6 +128,7 @@ func (r ReconcileMonitoring) Reconcile() error {
 		if err := controllerutil.SetControllerReference(r.cr, deployment, r.reconciler.Scheme); err != nil {
 			return err
 		}
+		applyAutoRestartSecretAnnotations(deployment, r.logger, monitoringSecret, backupDaemonSecret)
 		if err := r.reconciler.createOrUpdateDeployment(deployment, r.logger); err != nil {
 			return err
 		}

--- a/operator/controllers/zookeeper_reconciler.go
+++ b/operator/controllers/zookeeper_reconciler.go
@@ -188,6 +188,7 @@ func (r ReconcileZooKeeper) Reconcile() error {
 			if err := controllerutil.SetControllerReference(r.cr, serverDeployment, r.reconciler.Scheme); err != nil {
 				return err
 			}
+			applyAutoRestartSecretAnnotations(serverDeployment, r.logger, zooKeeperSecret)
 			if err := r.reconciler.createOrUpdateDeployment(serverDeployment, r.logger); err != nil {
 				return err
 			}


### PR DESCRIPTION
…upDaemon, Monitoring, and ZooKeeper

- Implemented `applyAutoRestartSecretAnnotations` in the Reconcile methods of BackupDaemon, Monitoring, and ZooKeeper reconciler to enhance deployment stability by automatically applying annotations for secret changes.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

TDB

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.
-->

- Related Issue  CPCAP-12170
- Closes #167 

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

### Breaking Change checklist
_If your PR includes any deployment or processing changes, please utilize this checklist:_
- [ ] Does it change any deployment parameters, logic of their working or rename them?
- [ ] Did update from previous version tested with the same set of deployment parameters?

## Added/updated tests?

- [ ] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## [optional] Are there any things to highlight or double check? 

## [optional] What gif best describes this PR or how it makes you feel?
